### PR TITLE
changing "run" to "start" for consistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM continuumio/miniconda3
 
 # docker build -t openbases/builder-bioschema
-# docker run -v $PWD:/data openbases/builder-bioschema
+# docker run -v $PWD:/data openbases/builder-bioschema .
 
 RUN apt-get update && apt-get install -y git wget
 RUN git clone -b remove-gdrive https://www.github.com/vsoch/map2model /code && \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ to generate a bioschemas specification using [map2model](https://www.github.com/
 to generate a specification for contribution to [bioschemas](https://www.github.com/openbases/specifications). You can use the container to generate your specification as follows:
 
  1. Fill in the templates provided on Google Drive, and download as tsv
- 2. Run the [openbases/openbases-bioschema]() container to generate your specification files
+ 2. Run the [openbases/openbases-bioschema](https://hub.docker.com/r/openbases/builder-bioschema) container to generate your specification files
  3. Contribute your specification by way of a pull request to [bioschemas](https://www.github.com/openbases/specifications)
 
 That's it! More information coming soon.
@@ -54,11 +54,11 @@ Usage:
          Commands:
 
                 help: show help and exit
-                run:   generate a specification, with your subdirectory with the
+                start:   generate a specification, with your subdirectory with the
                        specifications top level folder bound to /data
                 demo: show a demo generation using files in the container
          
-         Options [run]:
+         Options [start]:
 
             --config CONFIG     configuration.yml file, defaults to configuration.yml in
                                 folder
@@ -90,7 +90,7 @@ $PWD relative to /data in the container!
 
 ```
 mkdir -p outfiles
-$ docker run -it -v $PWD:/data openbases/builder-bioschema run --config /data/specifications/configuration.yml --output /data/outfiles
+$ docker run -it -v $PWD:/data openbases/builder-bioschema start --config /data/specifications/configuration.yml --output /data/outfiles
 ```
 
 Here are your files!

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,11 +13,11 @@ usage () {
          Commands:
 
                 help: show help and exit
-                run:   generate a specification, with your subdirectory with the
+                start: generate a specification, with your subdirectory with the
                        specifications top level folder bound to /data
                 demo: show a demo generation using files in the container
          
-         Options [run]:
+         Options [start]:
 
             --config CONFIG     configuration.yml file, defaults to configuration.yml in
                                 folder
@@ -49,7 +49,7 @@ while true; do
             shift
             OPENBASES_DEMO="yes"
         ;;
-        run)
+        run|start)
             shift
             OPENBASES_RUN="yes"
         ;;

--- a/specifications/configuration.yml
+++ b/specifications/configuration.yml
@@ -5,3 +5,9 @@ specifications:
   use_cases_url: https://docs.google.com/spreadsheets/d/1XzrZxFIuG3TS9RU8vACoUjAvaADLmI_FrIk7O3BEkxY/edit#gid=1439268036
   version: 0.2.0
   parent_type: CreativeWork
+- name : Container
+  status: revision
+  spec_type: Profile
+  use_cases_url: https://www.github.com/vsoch/bioschema-container
+  version: 0.0.1
+  parent_type: SoftwareApplication

--- a/specifications/configuration.yml
+++ b/specifications/configuration.yml
@@ -5,9 +5,3 @@ specifications:
   use_cases_url: https://docs.google.com/spreadsheets/d/1XzrZxFIuG3TS9RU8vACoUjAvaADLmI_FrIk7O3BEkxY/edit#gid=1439268036
   version: 0.2.0
   parent_type: CreativeWork
-- name : Container
-  status: revision
-  spec_type: Profile
-  use_cases_url: https://www.github.com/vsoch/bioschema-container
-  version: 0.0.1
-  parent_type: SoftwareApplication


### PR DESCRIPTION
It's redundant to have "run" twice, and I think more intuitive to use "start" so I want to change this for the container and docs about it.